### PR TITLE
Retry get Bucket on failure if possible

### DIFF
--- a/google-storage-agent/src/main/kotlin/jetbrains/buildServer/artifacts/google/publish/GoogleRegularFileUploader.kt
+++ b/google-storage-agent/src/main/kotlin/jetbrains/buildServer/artifacts/google/publish/GoogleRegularFileUploader.kt
@@ -7,6 +7,7 @@ import com.intellij.openapi.diagnostic.Logger
 import jetbrains.buildServer.agent.AgentRunningBuild
 import jetbrains.buildServer.agent.ArtifactPublishingFailedException
 import jetbrains.buildServer.artifacts.ArtifactDataInstance
+import jetbrains.buildServer.serverSide.artifacts.google.GoogleConstants
 import jetbrains.buildServer.serverSide.artifacts.google.GoogleUtils
 import kotlinx.coroutines.experimental.*
 import java.io.File
@@ -18,10 +19,43 @@ class GoogleRegularFileUploader : GoogleFileUploader {
     override fun publishFiles(build: AgentRunningBuild,
                               pathPrefix: String,
                               filesToPublish: Map<File, String>) = runBlocking {
-        val bucket = GoogleUtils.getStorageBucket(build.artifactStorageSettings)
+        val bucket = getBucket(build)
+
         return@runBlocking filesToPublish.map { (file, path) ->
             publishArtifactAsync(build, bucket, pathPrefix, file, path)
         }.map { it.await() }
+    }
+
+    private fun getBucket(build: AgentRunningBuild): Bucket {
+        val backOff = ExponentialBackOff()
+        val bucketName = build.artifactStorageSettings[GoogleConstants.PARAM_BUCKET_NAME]?.trim()
+        var backOffInterval: Long
+
+        do {
+            try {
+                return GoogleUtils.getStorageBucket(build.artifactStorageSettings)
+            } catch (e: Throwable) {
+                val message = "Failed to retrieve bucket: $bucketName"
+                LOG.infoAndDebugDetails(message, e)
+
+                if (e is StorageException) {
+                    if (e.isRetryable) {
+                        LOG.info(e.message)
+                        backOffInterval = backOff.nextBackOffMillis()
+                        if (backOffInterval != ExponentialBackOff.STOP) {
+                            build.buildLogger.message("$message. Will retry in ${backOffInterval / 1000} seconds.")
+                            Thread.sleep(backOffInterval)
+                            continue
+                        }
+                    }
+                    LOG.warn(e.message)
+                    build.buildLogger.error(e.message)
+                }
+
+                throw ArtifactPublishingFailedException(message, false, e)
+            }
+        } while (backOffInterval != ExponentialBackOff.STOP)
+        throw throw ArtifactPublishingFailedException("Failed to retrieve bucket: $bucketName after several retries", false, null)
     }
 
     private fun publishArtifactAsync(build: AgentRunningBuild,


### PR DESCRIPTION
GoogleUtils.getStorageBucket can throw StorageException
upon failure. This commit wrapps the call with a ExponentialBackOff
logic.